### PR TITLE
Couple of updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,18 +117,6 @@
 			<version>2.1</version>
 		</dependency>
 
-		<!-- Logging -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.6.4</version>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.0.1</version>
-		</dependency>
-
 		 <!-- Google Guava -->
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,11 @@
 	</build>
 
 	<dependencies>
-		<!-- Apache commons-lang -->
-                <dependency>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                    <version>3.1</version>
-                </dependency>
+		<dependency>
+			<groupId>com.neovisionaries</groupId>
+			<artifactId>nv-i18n</artifactId>
+			<version>1.22</version>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 	</licenses>
 
 	<properties>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -109,14 +109,6 @@
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
-
-		<!-- Joda Time - Java date and time API -->
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.1</version>
-		</dependency>
-
 		 <!-- Google Guava -->
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/src/main/java/nl/irp/sepa/BankToCustomerStatement.java
+++ b/src/main/java/nl/irp/sepa/BankToCustomerStatement.java
@@ -9,7 +9,6 @@ import iso.std.iso._20022.tech.xsd.camt_053_001.CashAccount16;
 import iso.std.iso._20022.tech.xsd.camt_053_001.CashAccount20;
 import iso.std.iso._20022.tech.xsd.camt_053_001.CashBalance3;
 import iso.std.iso._20022.tech.xsd.camt_053_001.CopyDuplicate1Code;
-import iso.std.iso._20022.tech.xsd.camt_053_001.DateTimePeriodDetails;
 import iso.std.iso._20022.tech.xsd.camt_053_001.Document;
 import iso.std.iso._20022.tech.xsd.camt_053_001.GroupHeader42;
 import iso.std.iso._20022.tech.xsd.camt_053_001.Pagination;

--- a/src/main/java/nl/irp/sepa/SEPACreditTransfer.java
+++ b/src/main/java/nl/irp/sepa/SEPACreditTransfer.java
@@ -1,31 +1,19 @@
 package nl.irp.sepa;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static nl.irp.sepa.Utils.*;
-import iso.std.iso._20022.tech.xsd.pain_001_001.ChargeBearerType1Code;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CreditTransferTransactionInformation10;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CustomerCreditTransferInitiationV03;
-import iso.std.iso._20022.tech.xsd.pain_001_001.Document;
-import iso.std.iso._20022.tech.xsd.pain_001_001.GroupHeader32;
-import iso.std.iso._20022.tech.xsd.pain_001_001.LocalInstrument2Choice;
-import iso.std.iso._20022.tech.xsd.pain_001_001.ObjectFactory;
-import iso.std.iso._20022.tech.xsd.pain_001_001.PaymentIdentification1;
-import iso.std.iso._20022.tech.xsd.pain_001_001.PaymentInstructionInformation3;
-import iso.std.iso._20022.tech.xsd.pain_001_001.PaymentMethod3Code;
-import iso.std.iso._20022.tech.xsd.pain_001_001.PaymentTypeInformation19;
-import iso.std.iso._20022.tech.xsd.pain_001_001.ServiceLevel8Choice;
-
-import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.util.Date;
-import java.util.UUID;
+import iso.std.iso._20022.tech.xsd.pain_001_001.*;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.datatype.DatatypeConfigurationException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
-import org.joda.time.LocalDate;
+import static com.google.common.base.Preconditions.checkArgument;
+import static nl.irp.sepa.Utils.*;
 
 /**
  * The Customer SEPA Credit Transfer Initiation message is sent by the initiating party to the debtor bank. It
@@ -69,7 +57,7 @@ public class SEPACreditTransfer {
 	 * @param name Name of the party that initiates the payment.
 	 * @throws DatatypeConfigurationException 
 	 */
-	public void buildGroupHeader(String msgId, String name, Date date) {
+	public void buildGroupHeader(String msgId, String name, LocalDateTime date) {
 		groupHeader =  new GroupHeader32();
 		// Point to point reference, as assigned by the instructing party, and sent to the next
 		// party in the chain to unambiguously identify the message.
@@ -83,7 +71,7 @@ public class SEPACreditTransfer {
 		groupHeader.setMsgId(msgId);
 		
 		// Date and time at which the message was created.
-		groupHeader.setCreDtTm( createXMLGregorianCalendar(date));
+		groupHeader.setCreDtTm( createXMLGregorianCalendarDate(date));
 		
 		// Number of individual transactions contained in the message.
 		groupHeader.setNbOfTxs("0");
@@ -106,9 +94,10 @@ public class SEPACreditTransfer {
 	 * included in the credit transfer initiation.
 	 * @param pmtInfId Unique identification, as assigned by a sending party, to unambiguously identify the 
 	 * payment information group within the message.
-	 * @param date This is the date on which the debtor's account is to be debited. 
+	 * @param reqdExctnDt This is the date on which the debtor's account is to be debited.
 	 * @param debtorNm Party that owes an amount of money to the (ultimate) creditor.
 	 * @param debtorAccountIBAN Unambiguous identification of the account of the debtor to which a debit 
+	 * @param financialInstitutionBIC BIC number of the financial institution
 	 * entry will be made as a result of the transaction.
 	 * @return 
 	 * @throws DatatypeConfigurationException
@@ -146,7 +135,7 @@ public class SEPACreditTransfer {
 		paymentInstructionInformation.setPmtTpInf(paymentTypeInformation);
 
 		// This is the date on which the debtor's account is to be debited. 
-		paymentInstructionInformation.setReqdExctnDt( createXMLGregorianCalendarDate(reqdExctnDt.toDate()));
+		paymentInstructionInformation.setReqdExctnDt( Utils.createXMLGregorianCalendarDate(reqdExctnDt));
 		
 		// Party that owes an amount of money to the (ultimate) creditor.
 		paymentInstructionInformation.setDbtr( createParty(debtorNm) );

--- a/src/main/java/nl/irp/sepa/Utils.java
+++ b/src/main/java/nl/irp/sepa/Utils.java
@@ -1,30 +1,17 @@
 package nl.irp.sepa;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import iso.std.iso._20022.tech.xsd.pain_001_001.AccountIdentification4Choice;
-import iso.std.iso._20022.tech.xsd.pain_001_001.ActiveOrHistoricCurrencyAndAmount;
-import iso.std.iso._20022.tech.xsd.pain_001_001.AmountType3Choice;
-import iso.std.iso._20022.tech.xsd.pain_001_001.BranchAndFinancialInstitutionIdentification4;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CashAccount16;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CreditorReferenceInformation2;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CreditorReferenceType1Choice;
-import iso.std.iso._20022.tech.xsd.pain_001_001.CreditorReferenceType2;
-import iso.std.iso._20022.tech.xsd.pain_001_001.DocumentType3Code;
-import iso.std.iso._20022.tech.xsd.pain_001_001.FinancialInstitutionIdentification7;
-import iso.std.iso._20022.tech.xsd.pain_001_001.PartyIdentification32;
-import iso.std.iso._20022.tech.xsd.pain_001_001.RemittanceInformation5;
-import iso.std.iso._20022.tech.xsd.pain_001_001.StructuredRemittanceInformation7;
-
-import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.regex.Pattern;
+import iso.std.iso._20022.tech.xsd.pain_001_001.*;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class Utils {
 	
@@ -32,38 +19,27 @@ public class Utils {
 	private static Pattern bicRegex =
 			Pattern.compile("([a-zA-Z]{4}[a-zA-Z]{2}[a-zA-Z0-9]{2}([a-zA-Z0-9]{3})?)");
 
-	public static XMLGregorianCalendar createXMLGregorianCalendar(Date currentDateTime) {
-		GregorianCalendar calendar = new GregorianCalendar();
-		calendar.setTime(currentDateTime);
-
-		XMLGregorianCalendar createDate;
+	public static XMLGregorianCalendar createXMLGregorianCalendarDate(LocalDate currentDateTime) {
 		try {
-			createDate = DatatypeFactory.newInstance().newXMLGregorianCalendar(calendar);
-			createDate.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
-			createDate.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
+			return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+					currentDateTime.getYear(), currentDateTime.getMonthValue(), currentDateTime.getDayOfMonth(),
+					DatatypeConstants.FIELD_UNDEFINED);
 		} catch (DatatypeConfigurationException e) {
 			throw new RuntimeException(e);
 		}
-
-		return createDate;
 	}
-	
-	public static XMLGregorianCalendar createXMLGregorianCalendarDate(Date currentDateTime) {
-		GregorianCalendar calendar = new GregorianCalendar();
-		calendar.setTime(currentDateTime);
 
-		XMLGregorianCalendar createDate;
+	public static XMLGregorianCalendar createXMLGregorianCalendarDate(LocalDateTime currentDateTime) {
 		try {
-			createDate = DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
-				calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH)+1, calendar.get(Calendar.DAY_OF_MONTH),
-				DatatypeConstants.FIELD_UNDEFINED);
+			return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+					currentDateTime.getYear(), currentDateTime.getMonthValue(), currentDateTime.getDayOfMonth(),
+					currentDateTime.getHour(), currentDateTime.getMinute(), currentDateTime.getSecond(), DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED);
 		} catch (DatatypeConfigurationException e) {
 			throw new RuntimeException(e);
 		}
-
-		return createDate;
 	}
-	
+
+
 	/**
 	 * Information supplied to enable the matching of an entry with the items that the
 	 * transfer is intended to settle, such as commercial invoices in an accounts' receivable

--- a/src/main/java/nl/irp/sepa/sdd/DirectDebitInitiation.java
+++ b/src/main/java/nl/irp/sepa/sdd/DirectDebitInitiation.java
@@ -8,7 +8,6 @@ import static nl.irp.sepa.sdd.Utils.createIdParty;
 import static nl.irp.sepa.sdd.Utils.createParty;
 import static nl.irp.sepa.sdd.Utils.createPaymentIdentification;
 import static nl.irp.sepa.sdd.Utils.createRmtInf;
-import static nl.irp.sepa.sdd.Utils.createXMLGregorianCalendar;
 import static nl.irp.sepa.sdd.Utils.createXMLGregorianCalendarDate;
 import iso.std.iso._20022.tech.xsd.pain_008_001.ChargeBearerType1Code;
 import iso.std.iso._20022.tech.xsd.pain_008_001.CustomerDirectDebitInitiationV02;
@@ -28,6 +27,8 @@ import iso.std.iso._20022.tech.xsd.pain_008_001.ServiceLevel8Choice;
 
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -35,8 +36,6 @@ import java.util.UUID;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-
-import org.joda.time.LocalDate;
 
 
 /**
@@ -64,7 +63,7 @@ public class DirectDebitInitiation {
 	 * @param name
 	 * @param date
 	 */
-	public void buildGroupHeader(String msgId, String name, Date date) {
+	public void buildGroupHeader(String msgId, String name, LocalDateTime date) {
 		groupHeader = new GroupHeader39();
 		
 		// if no msgId is given create one
@@ -75,7 +74,7 @@ public class DirectDebitInitiation {
 		groupHeader.setMsgId(msgId);
 		
 		// Date and time at which the message was created.
-		groupHeader.setCreDtTm( createXMLGregorianCalendar(date));
+		groupHeader.setCreDtTm( nl.irp.sepa.Utils.createXMLGregorianCalendarDate(date));
 		
 		// Number of individual transactions contained in the message.
 		groupHeader.setNbOfTxs("0");
@@ -100,7 +99,7 @@ public class DirectDebitInitiation {
 	}
 	
 	public PaymentInstruction paymentInstruction(
-			String pmtInfId, Date reqdColltnDt, 
+			String pmtInfId, LocalDate reqdColltnDt,
 			String creditor, SequenceType1Code type,
 			String creditorCountry, List<String> addressLines, 
 			String creditorAccount, String creditorBic) {
@@ -125,7 +124,7 @@ public class DirectDebitInitiation {
 		 * collected from the debtor.
 		 */
 		public PaymentInstruction(
-				String pmtInfId, Date reqdColltnDt, 
+				String pmtInfId, LocalDate reqdColltnDt,
 				String creditor, SequenceType1Code type,
 				String creditorCountry, List<String> addressLines,
 				String creditorAccount, String creditorBic) {
@@ -260,7 +259,7 @@ public class DirectDebitInitiation {
 			
 			MandateRelatedInformation6 mandateInf = new MandateRelatedInformation6();
 			mandateInf.setMndtId(mandateId);
-			mandateInf.setDtOfSgntr( createXMLGregorianCalendarDate(dtOfSgntr.toDate()));
+			mandateInf.setDtOfSgntr(createXMLGregorianCalendarDate(dtOfSgntr));
 			mandateInf.setAmdmntInd(false);
 			transaction.setMndtRltdInf(mandateInf);
 

--- a/src/main/java/nl/irp/sepa/sdd/Utils.java
+++ b/src/main/java/nl/irp/sepa/sdd/Utils.java
@@ -22,9 +22,7 @@ import iso.std.iso._20022.tech.xsd.pain_008_001.RemittanceInformation5;
 import iso.std.iso._20022.tech.xsd.pain_008_001.StructuredRemittanceInformation7;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -38,37 +36,15 @@ public class Utils {
 	
 	private static Pattern bicRegex =
 			Pattern.compile("([a-zA-Z]{4}[a-zA-Z]{2}[a-zA-Z0-9]{2}([a-zA-Z0-9]{3})?)");
-
-	public static XMLGregorianCalendar createXMLGregorianCalendar(Date currentDateTime) {
-		GregorianCalendar calendar = new GregorianCalendar();
-		calendar.setTime(currentDateTime);
-
-		XMLGregorianCalendar createDate;
-		try {
-			createDate = DatatypeFactory.newInstance().newXMLGregorianCalendar(calendar);
-			createDate.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
-			createDate.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
-		} catch (DatatypeConfigurationException e) {
-			throw new RuntimeException(e);
-		}
-
-		return createDate;
-	}
 	
-	public static XMLGregorianCalendar createXMLGregorianCalendarDate(Date currentDateTime) {
-		GregorianCalendar calendar = new GregorianCalendar();
-		calendar.setTime(currentDateTime);
-
-		XMLGregorianCalendar createDate;
+	public static XMLGregorianCalendar createXMLGregorianCalendarDate(LocalDate currentDateTime) {
 		try {
-			createDate = DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
-				calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH)+1, calendar.get(Calendar.DAY_OF_MONTH),
+			return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+				currentDateTime.getYear(), currentDateTime.getMonthValue(), currentDateTime.getDayOfMonth(),
 				DatatypeConstants.FIELD_UNDEFINED);
 		} catch (DatatypeConfigurationException e) {
 			throw new RuntimeException(e);
 		}
-
-		return createDate;
 	}
 	
 	/**

--- a/src/test/java/nl/irp/sepa/BankToCustomerStatementTest.java
+++ b/src/test/java/nl/irp/sepa/BankToCustomerStatementTest.java
@@ -1,20 +1,18 @@
 package nl.irp.sepa;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.xml.bind.JAXBException;
-
-import nl.irp.sepa.BankToCustomerStatement.AccountStatement;
-
-import org.joda.time.DateTime;
-import org.junit.Test;
-
 import com.google.common.io.InputSupplier;
 import com.google.common.io.Resources;
+import nl.irp.sepa.BankToCustomerStatement.AccountStatement;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 public class BankToCustomerStatementTest {
 
@@ -27,19 +25,17 @@ public class BankToCustomerStatementTest {
 		
 		// GrpHdr
 		assertThat(bankToCustomerStatement.getMsgId(), is("AAAASESS-FP-STAT001"));
-		assertThat(bankToCustomerStatement.getCreDtTm(), is(new DateTime("2010-10-18T17:00:00+01:00").toDate()));
+		assertThat(bankToCustomerStatement.getCreDtTm(), is(Date.from(ZonedDateTime.parse("2010-10-18T17:00:00+01:00").toInstant())));
 		assertThat(bankToCustomerStatement.getMsgPgntn().getPgNb(), is("1"));
 		assertThat(bankToCustomerStatement.getMsgPgntn().isLastPgInd(), is(true));
 
 		AccountStatement stmt = bankToCustomerStatement.getStmt().get(0);
 		
 		assertThat(stmt.getId(), is("AAAASESS-FP-STAT001"));
-		assertThat(stmt.getCreDtTm(), is(new DateTime("2010-10-18T17:00:00+01:00").toDate()));
+		assertThat(stmt.getCreDtTm(), is(Date.from(ZonedDateTime.parse("2010-10-18T17:00:00+01:00").toInstant())));
 		
-		assertThat(stmt.getFrDt(), is(new DateTime("2010-10-18T08:00:00+01:00").toDate()));
-		assertThat(stmt.getToDt(), is(new DateTime("2010-10-18T17:00:00+01:00").toDate()));
-		
-		
+		assertThat(stmt.getFrDt(), is(Date.from(ZonedDateTime.parse("2010-10-18T08:00:00+01:00").toInstant())));
+		assertThat(stmt.getToDt(), is(Date.from(ZonedDateTime.parse("2010-10-18T17:00:00+01:00").toInstant())));
 	}
 
 }

--- a/src/test/java/nl/irp/sepa/DirectDebitInitiationTest.java
+++ b/src/test/java/nl/irp/sepa/DirectDebitInitiationTest.java
@@ -5,6 +5,8 @@ import iso.std.iso._20022.tech.xsd.pain_008_001.SequenceType1Code;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 
 import javax.xml.bind.JAXBException;
@@ -18,8 +20,6 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLTestCase;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalDateTime;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -45,15 +45,15 @@ public class DirectDebitInitiationTest extends XMLTestCase {
 	
 	@Test
 	public void testABN() throws DatatypeConfigurationException, JAXBException, XpathException, SAXException, IOException {
-		LocalDateTime today = new LocalDateTime("2012-02-22T09:29:54"); 
+		LocalDateTime today = LocalDateTime.parse("2012-02-22T09:29:54");
 		DirectDebitInitiation debitInitiation = new DirectDebitInitiation();
 		
-		debitInitiation.buildGroupHeader("1000004207", "Naam", today.toDate());
+		debitInitiation.buildGroupHeader("1000004207", "Naam", today);
 		
 		String pmtInfId = "1000004207";
 		PaymentInstruction paymentInstruction = debitInitiation
 			.paymentInstruction(
-				pmtInfId, new LocalDate(2012, 2, 21).toDate(),
+				pmtInfId, LocalDate.of(2012, 2, 21),
 				"Naam", SequenceType1Code.RCUR,
 				"NL", ImmutableList.of("Dorpstraat 1", "Amsterdam"),
 				"DE12345678901234567890", "ABNADEFFFRA");
@@ -62,7 +62,7 @@ public class DirectDebitInitiationTest extends XMLTestCase {
 			"01-E30220000000382012",     //InstrId
 			"2000000038",                //EndToEndId
 			new BigDecimal("1600.00"),
-			"MANDAAT123456", new LocalDate("2010-09-05"), "NL89ZZZ011234567890",
+			"MANDAAT123456", LocalDate.parse("2010-09-05"), "NL89ZZZ011234567890",
 			"FICO Customer account",
 			"DE12345678901234567890", "NBAGDE3E",
 			"DE", ImmutableList.of("123, ABC street", "32547 Frankfurt Germany"),
@@ -80,15 +80,15 @@ public class DirectDebitInitiationTest extends XMLTestCase {
 	
 	@Test
 	public void testING() throws DatatypeConfigurationException, JAXBException, XpathException, SAXException, IOException {
-		LocalDateTime today = new LocalDateTime("2012-02-22T09:29:54"); 
+		LocalDateTime today = LocalDateTime.parse("2012-02-22T09:29:54");
 		DirectDebitInitiation debitInitiation = new DirectDebitInitiation();
 		
-		debitInitiation.buildGroupHeader("MSGID001", "IPNORGANISATIENAAM", today.toDate());
+		debitInitiation.buildGroupHeader("MSGID001", "IPNORGANISATIENAAM", today);
 		
 		String pmtInfId = "PAYID001";
 		PaymentInstruction paymentInstruction = debitInitiation
 			.paymentInstruction(
-				pmtInfId, new LocalDate("2012-02-05").toDate(),
+				pmtInfId, LocalDate.parse("2012-02-05"),
 				"NAAM", SequenceType1Code.OOFF,
 				"NL", ImmutableList.of("Dorpstraat 1", "Amsterdam"),
 				"NL28INGB0000000001", "INGBNL2A");
@@ -97,7 +97,7 @@ public class DirectDebitInitiationTest extends XMLTestCase {
 			"01-E30220000000382012",     //InstrId
 			"E2EID001",                //EndToEndId
 			new BigDecimal("1.01"),
-			"MANDAATIDNR001", new LocalDate("2011-12-31"), "NL89ZZZ011234567890",
+			"MANDAATIDNR001", LocalDate.parse("2011-12-31"), "NL89ZZZ011234567890",
 			"NAAM",
 			"NL98INGB0000000002", "INGBNL2A",
 			"DE", ImmutableList.of("123, ABC street", "32547 Frankfurt Germany"),

--- a/src/test/java/nl/irp/sepa/IBANUtilsTest.java
+++ b/src/test/java/nl/irp/sepa/IBANUtilsTest.java
@@ -27,7 +27,7 @@ public class IBANUtilsTest {
 	
 	@Test
 	public void testValidate() {
-		assertThat(IBANUtils.validate(iban_nl), is(true));
+		assertThat(IBANUtils.validate("NL49ABNA0414114988"), is(true));
 	}
 
 }

--- a/src/test/java/nl/irp/sepa/SEPACreditTransferTest.java
+++ b/src/test/java/nl/irp/sepa/SEPACreditTransferTest.java
@@ -3,6 +3,8 @@ package nl.irp.sepa;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 
 import javax.xml.bind.JAXBException;
@@ -13,8 +15,6 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLTestCase;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalDateTime;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -39,13 +39,13 @@ public class SEPACreditTransferTest extends XMLTestCase {
 	
 	@Test
 	public void testABN() throws DatatypeConfigurationException, JAXBException, XpathException, SAXException, IOException {
-		LocalDateTime today = new LocalDateTime("2013-04-02T14:52:09"); 
+		LocalDateTime today = LocalDateTime.parse("2013-04-02T14:52:09");
 		SEPACreditTransfer transfer = new SEPACreditTransfer();
 		
-		transfer.buildGroupHeader("000001", "Klantnaam", today.toDate());
+		transfer.buildGroupHeader("000001", "Klantnaam", today);
 		
 		transfer
-			.betaalgroep("12345", new LocalDate("2013-04-19"), "Debiteur", "NL02ABNA0123456789", "ABNANL2A")
+			.betaalgroep("12345", LocalDate.parse("2013-04-19"), "Debiteur", "NL02ABNA0123456789", "ABNANL2A")
 				.creditTransfer("Onze referentie: 123456", new BigDecimal("386.00"), "RABONL2U", "Crediteur", "NL44RABO0123456789", "Ref. 2012.0386");
 		
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -58,13 +58,13 @@ public class SEPACreditTransferTest extends XMLTestCase {
 	
 	@Test
 	public void testING() throws DatatypeConfigurationException, JAXBException, XpathException, SAXException, IOException {
-		LocalDateTime today = new LocalDateTime("2013-04-02T14:52:09"); 
+		LocalDateTime today = LocalDateTime.parse("2013-04-02T14:52:09");
 		SEPACreditTransfer transfer = new SEPACreditTransfer();
 		
-		transfer.buildGroupHeader("MSGID005", "IPNORGANIZTIONNAME", today.toDate());
+		transfer.buildGroupHeader("MSGID005", "IPNORGANIZTIONNAME", today);
 		
 		transfer
-			.betaalgroep("PAYID001", new LocalDate("2013-04-19"), "NAAM Debtor", "NL28INGB0000000001", "INGBNL2A")
+			.betaalgroep("PAYID001", LocalDate.parse("2013-04-19"), "NAAM Debtor", "NL28INGB0000000001", "INGBNL2A")
 				.creditTransfer("E2EID001", new BigDecimal("1.01"), "INGBNL2A", "NAAM cdtr", "NL98INGB0000000002", "Ref. 2012.0386");
 		
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();


### PR DESCRIPTION
The associated PR applies some changes that we have made to the local fork we using. It may not be useful to others, but I figured I could at least put it out here. Changes made:

- Remove dependency on commons-io (could easily be omitted, and avoids conflicts in application servers that serve other versions of commons io)
- Altered IBAN validation. I don't exactly remember why, but as far as I remember, in the previous library, I had some invalid IBANs ending up in the SEPA batch and therefore failing the entire thing. But I am not entirely sure anymore.
- Migration to Java 8, and use of Java 8's date time API so that dependency on Joda time could be removed

In the last I've decided to go for  LocalDateTime as opposed to their zoned counterpart. While I think (but not am entirely sure) the XML format support zoned timestamps fine, I wanted to stay closes as possible to the original code and make the tests pass without tempering with the provided XML files.